### PR TITLE
[Modify]雑談API 会話時のcontext指定方法の変更

### DIFF
--- a/src/Talk.php
+++ b/src/Talk.php
@@ -8,26 +8,25 @@ class Talk extends DocomoApi
 {
     const ENDPOINT = 'https://api.apigw.smt.docomo.ne.jp/dialogue/v1/dialogue';
 
-    /** @var string|null $context */
-    private $context = null;
-
     /**
      * @param string $utt 発話内容
-     * @param boolean $kaiwa 会話を継続するかどうかフラグ
+     * @param string $context 会話を継続する場合のcontext。前回のresponse bodyから取得
      * @return array
      */
-    public function request($utt, $kaiwa = false)
+    public function request($utt, $context = '')
     {
         $data = ['utt' => $utt];
-        if (isset($this->context)) {
-            $data['context'] = $this->context;
+        if (
+            is_string($context) &&
+            strlen($context)
+        ) {
+            $data['context'] = $context;
         }
         $res = $this->post(
             self::ENDPOINT,
             json_encode($data),
             ['Content-Type: application/json']
         );
-        $this->context = $kaiwa ? $res['body']['context'] : null;
         return $res;
     }
 }


### PR DESCRIPTION
contextをインスタンスのプロパティに保持するのではなく、発話時に引数で指定するように修正。
